### PR TITLE
feat: implement assign admin mapping on assign admin modal in users

### DIFF
--- a/web-react-ts/src/auth/PrivateRoute.tsx
+++ b/web-react-ts/src/auth/PrivateRoute.tsx
@@ -44,7 +44,9 @@ const PrivateRoute: React.FC<ProtectedRouteProps> = (props) => {
     return children
   }
 
-  !currentUser && <Navigate to="/login" />
+  if (!currentUser) {
+    return <Navigate to="/login" />
+  }
 
   if (isAuthorised(roles, userRoles)) {
     return children

--- a/web-react-ts/src/components/Navigation.tsx
+++ b/web-react-ts/src/components/Navigation.tsx
@@ -31,7 +31,8 @@ function Navigation() {
   const btnRef = React.useRef(null)
   const navigate = useNavigate()
   const { userProfile } = useUserContext()
-  const { userInfo } = useAuth()
+
+  const { userInfo, currentUser } = useAuth()
   const { navBg, sideBarBackground } = useCustomColors()
 
   let menuItems: { name: string; link: string }[] = []

--- a/web-react-ts/src/components/RoleCard.tsx
+++ b/web-react-ts/src/components/RoleCard.tsx
@@ -33,6 +33,7 @@ const RoleCard = ({ role, name }: RoleCardProps) => {
     case 'campusAdmin':
     case 'countryAdmin':
     case 'continentAdmin':
+    case 'campAdmin':
       roleText = 'Admin'
       route = '/admin'
       break

--- a/web-react-ts/src/components/modals/AssignAdminUserModal.tsx
+++ b/web-react-ts/src/components/modals/AssignAdminUserModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import {
   Modal,
   ModalOverlay,
@@ -13,14 +13,17 @@ import {
   useToast,
 } from '@chakra-ui/react'
 import { Select } from '@jaedag/admin-portal-react-core'
-import { ModalProps, SelectOptions } from '../../../global'
+import { ModalProps, SelectOptions, UserCampData } from '../../../global'
 import * as Yup from 'yup'
 import { useForm } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import { getFunctions, httpsCallable } from 'firebase/functions'
 import { churchLevel } from '../../utils/utils'
-import { doc, getDoc, updateDoc } from 'firebase/firestore'
+import { doc, getDoc, updateDoc, collection, getDocs } from 'firebase/firestore'
 import { useFirestore } from 'reactfire'
+import { useAuth } from '../../contexts/AuthContext'
+import { useUserContext } from '../../contexts/UserContext'
+import { ROLE_MAPPINGS, ROLE_WEIGHTS } from '../../utils/constants'
 
 interface AssignAdminToCampModalProps extends ModalProps {
   user: string
@@ -33,33 +36,133 @@ const AssignAdminToCampModal = ({
   user,
   campOptions,
 }: AssignAdminToCampModalProps) => {
-  //   const campOptions = [{ key: 'abcde', value: 'abcde' }]
   const firestore = useFirestore()
   const toast = useToast()
+  const { currentUser } = useAuth()
+  const [campAdminOptions, setCampAdminOptions] = useState<SelectOptions[]>([])
+  const [campusOptions, setCampusOptions] = useState<SelectOptions[]>([])
+  const { userRoles } = useUserContext()
 
-  const initialValues = {
+  const adminLevels = async (campId: string, finalRoles: string[]) => {
+    try {
+      setCampAdminOptions([])
+      if (campId) {
+        const campReference = doc(firestore, 'camps', campId)
+        const campData = await getDoc(campReference)
+        const camp = campData.data()
+        const campLevel = camp?.campLevel
+        const adminLevels: SelectOptions[] = []
+
+        const allowedRoles = ROLE_MAPPINGS[campLevel] || {}
+
+        finalRoles.forEach((userRole) => {
+          const allowedRoleList = allowedRoles[userRole] || []
+
+          allowedRoleList.forEach((role: string) => {
+            console.log('role', role)
+            const level = {
+              key: `${role} Admin`,
+              value: role.toLowerCase().replace(' ', ''),
+            }
+            adminLevels.push(level)
+          })
+        })
+
+        setCampAdminOptions(adminLevels)
+      }
+    } catch (error) {
+      console.log(error)
+    }
+  }
+
+  type InitialValues = { campLevel: string; camp: string; campus?: string }
+
+  const initialValues: InitialValues = {
     campLevel: '',
     camp: '',
+    campus: '',
   }
 
   const validationSchema = Yup.object({
     campLevel: Yup.string().required('Camp Level is a required field'),
     camp: Yup.string().required('Camp is a required field'),
+    campus: Yup.string().when('campLevel', ([campLevel], schema) => {
+      return campLevel === 'campus'
+        ? schema.required('Campus is a required field')
+        : schema
+    }),
   })
 
   const {
     handleSubmit,
+    watch,
     control,
     formState: { errors, isSubmitting },
-  } = useForm<typeof initialValues>({
+  } = useForm<InitialValues>({
     resolver: yupResolver(validationSchema),
     defaultValues: initialValues,
   })
 
+  const watchCamp = watch('camp')
+  const watchCampLevel = watch('campLevel')
+  console.log('watchCampLevel', watchCampLevel)
+
+  const highestUserRole = (roles: string[]) => {
+    console.log('roles', roles)
+    const highestWeightRole = roles.reduce((prevRole, currentRole) => {
+      const prevWeight =
+        ROLE_WEIGHTS.find((role) => role.role === prevRole)?.weight || 0
+      const currentWeight =
+        ROLE_WEIGHTS.find((role) => role.role === currentRole)?.weight || 0
+
+      return currentWeight > prevWeight ? currentRole : prevRole
+    }, '')
+
+    return highestWeightRole
+  }
+
+  useEffect(() => {
+    const campUserRoles = async (userEmail: string, watchCamp: string) => {
+      const currenUserDoc = doc(firestore, 'users', userEmail || '')
+      const currenUserData = await getDoc(currenUserDoc)
+      const campAdmin: UserCampData[] = currenUserData?.data()?.camp_admin || []
+      const userCamp = campAdmin.find((camp) => camp.campId === watchCamp)
+
+      if (userRoles.includes('globalAdmin')) {
+        adminLevels(watchCamp, ['globalAdmin'])
+      } else if (userCamp?.role) {
+        const highestRole = highestUserRole(userCamp?.role)
+        adminLevels(watchCamp, [highestRole])
+      }
+    }
+
+    campUserRoles(currentUser?.email || '', watchCamp)
+  }, [watchCamp, userRoles])
+
+  useEffect(() => {
+    const fetchCampuses = async (campId: string) => {
+      const campusesRef = collection(firestore, 'camps', campId, 'campuses')
+      const campusesSnapshot = await getDocs(campusesRef)
+      const campuses: SelectOptions[] = []
+
+      campusesSnapshot.docs.map((doc) =>
+        campuses.push({ key: doc.data().name, value: doc.id })
+      )
+
+      setCampusOptions(campuses)
+    }
+
+    if (watchCamp) {
+      fetchCampuses(watchCamp)
+    }
+  }, [watchCampLevel, watchCamp])
+
   const handleSubmitForm = async (values: typeof initialValues) => {
     try {
+      console.log('values', values)
       const campLevel = values.campLevel
       const campId = values.camp
+      const campusId = values?.campus
 
       const camp =
         campOptions && campOptions.find((camp) => camp.value === campId)
@@ -72,27 +175,52 @@ const AssignAdminToCampModal = ({
 
       await addClaimsToUser({
         email: user,
-        permission: campLevel,
+        permission: `${campLevel}Admin`,
       })
 
       const userReference = doc(firestore, 'users', user)
       //TODO check if the camp already exists in the user's camp_admin array
       const userData = await getDoc(doc(firestore, 'users', user))
-      const adminCamps = userData.data()?.camp_admin || []
+      const adminCamps: UserCampData[] = userData.data()?.camp_admin || []
+      // Check if the user is already assigned to the camp
+      const existingCampIndex = adminCamps.findIndex(
+        (camp) => camp.campId === campId
+      )
 
-      const campAdmin = [...adminCamps]
+      if (existingCampIndex !== -1) {
+        // Update the existing roles if the user is already assigned to the camp
+        const existingRoles = adminCamps[existingCampIndex].role || []
+        const updatedRoles = Array.from(
+          new Set([...existingRoles, `${campLevel}Admin`])
+        )
 
-      const newCampObject = {
-        campId: campId,
-        churchLevel: churchLevel(campLevel),
-        name: camp?.key,
-        role: campLevel,
+        adminCamps[existingCampIndex].role = updatedRoles
+
+        // Add campusId when campLevel is "campus"
+        if (campLevel === 'campus') {
+          adminCamps[existingCampIndex].campusId = campusId || undefined
+        }
+      } else {
+        // Add a new object to the camp_admin array
+        const newCampObject = {
+          campId: campId,
+          churchLevel: campLevel,
+          name: (camp?.key as string) || '',
+          role: [`${campLevel}Admin`],
+        }
+
+        // Add campusId when campLevel is "campus"
+        if (campLevel === 'campus') {
+          newCampObject.campusId = campusId || undefined
+        }
+
+        adminCamps.push(newCampObject)
       }
-      campAdmin.push(newCampObject)
 
       await updateDoc(userReference, {
-        camp_admin: campAdmin,
+        camp_admin: adminCamps,
       })
+
       onClose()
       toast({
         title: 'User Assigned',
@@ -129,30 +257,35 @@ const AssignAdminToCampModal = ({
 
           <form onSubmit={handleSubmit(handleSubmitForm)}>
             <Box my={3}>
+              <Box my={3}>
+                <Select
+                  name="camp"
+                  label="Camps"
+                  placeholder="Camps"
+                  options={campOptions}
+                  control={control}
+                  errors={errors}
+                />
+              </Box>
+
               <Select
                 name="campLevel"
                 label="Level"
                 placeholder="Level"
-                options={[
-                  { key: 'Campus Admin', value: 'campusAdmin' },
-                  { key: 'Country Admin', value: 'countryAdmin' },
-                  { key: 'Continent Admin', value: 'continentAdmin' },
-                  { key: 'Global Admin', value: 'globalAdmin' },
-                ]}
+                options={campAdminOptions}
                 control={control}
                 errors={errors}
               />
-            </Box>
-
-            <Box my={3}>
-              <Select
-                name="camp"
-                label="Camps"
-                placeholder="Camps"
-                options={campOptions}
-                control={control}
-                errors={errors}
-              />
+              {watchCampLevel && watchCampLevel === 'campus' && (
+                <Select
+                  name="campus"
+                  label="Campus"
+                  placeholder="Campus"
+                  options={campusOptions}
+                  control={control}
+                  errors={errors}
+                />
+              )}
             </Box>
 
             <ModalFooter>

--- a/web-react-ts/src/contexts/AuthContext.tsx
+++ b/web-react-ts/src/contexts/AuthContext.tsx
@@ -138,7 +138,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
   const getUsers = async (user: User | null) => {
     if (!user || !user.email) return
-    const userDoc = await doc(db, 'users', user.email)
+    const userDoc = doc(db, 'users', user.email)
     const userSnapShot = await getDoc(userDoc)
 
     return userSnapShot.exists() ? userSnapShot.data() : null
@@ -149,16 +149,24 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       setCurrentUser(user as User)
       setLoading(false)
     })
+
     return unsubscribe
   }, [])
 
   useEffect(() => {
+    let isMounted = true
+
     const Retrieval = async () => {
       const map = await getUsers(currentUser)
-      if (!map) return
+      if (!map || !isMounted) return
+
       setUserInfo(map)
     }
     Retrieval()
+
+    return () => {
+      isMounted = false // Set isMounted to false when the component unmounts
+    }
   }, [currentUser])
 
   const value = {

--- a/web-react-ts/src/contexts/UserContext.tsx
+++ b/web-react-ts/src/contexts/UserContext.tsx
@@ -7,6 +7,8 @@ import React, {
 } from 'react'
 
 interface UserContextType {
+  userRoles: string[]
+  setUserRoles: (roles: string[]) => void
   userProfile: string
   setUserProfile: (userProfile: string) => void
 }
@@ -14,6 +16,8 @@ interface UserContextType {
 const UserContext = createContext<UserContextType>({
   userProfile: '',
   setUserProfile: () => null,
+  userRoles: [],
+  setUserRoles: () => null,
 })
 
 export const useUserContext = () => {
@@ -21,6 +25,15 @@ export const useUserContext = () => {
 }
 
 export const UserContextProvider = ({ children }: { children: ReactNode }) => {
+  const [userRoles, setUserRoles] = useState<string[]>(
+    JSON.parse(sessionStorage.getItem('userRoles') || '[]')
+  )
+
+  const setUserRolesArray = (roles: string[]) => {
+    setUserRoles(roles)
+    sessionStorage.setItem('userRoles', JSON.stringify(roles))
+  }
+
   const [userProfile, setUserProfile] = useState<string>(
     sessionStorage.getItem('userProfile') ?? ''
   )
@@ -32,10 +45,12 @@ export const UserContextProvider = ({ children }: { children: ReactNode }) => {
 
   const value = useMemo(
     () => ({
+      userRoles,
+      setUserRoles: setUserRolesArray,
       userProfile,
       setUserProfile: setUserProfileText,
     }),
-    [userProfile]
+    [userRoles]
   )
 
   return <UserContext.Provider value={value}>{children}</UserContext.Provider>

--- a/web-react-ts/src/pages/camps/StartCampForm.tsx
+++ b/web-react-ts/src/pages/camps/StartCampForm.tsx
@@ -102,8 +102,6 @@ const StartCampForm = () => {
       levelId: levelId,
     }
 
-    console.log(data)
-
     const docRef = await addDoc(collection(firestore, 'camps'), data)
     console.log('Document written with ID: ', docRef.id)
 
@@ -121,9 +119,6 @@ const StartCampForm = () => {
           planets.push({ key: doc.data().name, value: doc.id })
         )
 
-        console.log('planets', planets)
-        console.log('snapshot', querySnapshot)
-
         setPlanets(planets)
       } catch (error) {
         console.error(error)
@@ -136,19 +131,21 @@ const StartCampForm = () => {
   useEffect(() => {
     const fetchContinents = async () => {
       try {
-        const continentsCollection = collection(firestore, 'continents')
+        if (watchWorld) {
+          const continentsCollection = collection(firestore, 'continents')
 
-        const continents: SelectOptions[] = []
-        const continentsQuery = query(
-          continentsCollection,
-          where('upperChurchId', '==', watchWorld)
-        )
-        const querySnapshot = await getDocs(continentsQuery)
-        querySnapshot.docs.map((doc) =>
-          continents.push({ key: doc.data().name, value: doc.id })
-        )
+          const continents: SelectOptions[] = []
+          const continentsQuery = query(
+            continentsCollection,
+            where('upperChurchId', '==', watchWorld)
+          )
+          const querySnapshot = await getDocs(continentsQuery)
+          querySnapshot.docs.map((doc) =>
+            continents.push({ key: doc.data().name, value: doc.id })
+          )
 
-        setContinents(continents)
+          setContinents(continents)
+        }
       } catch (error) {
         console.error(error)
       }

--- a/web-react-ts/src/pages/directory/profiles/PlanetProfile.tsx
+++ b/web-react-ts/src/pages/directory/profiles/PlanetProfile.tsx
@@ -29,7 +29,7 @@ const PlanetProfile = () => {
     <ApolloWrapper data={planet} loading={loading} error={error}>
       <Container>
         <Box>
-          <Heading mt={6}>{capitalizeFirstLetter(planet?.name)}</Heading>
+          <Heading mt={6}>{planet?.name}</Heading>
           <Text>World</Text>
           <Box my={6}>
             <DetailsCard

--- a/web-react-ts/src/pages/home/LandingPage.tsx
+++ b/web-react-ts/src/pages/home/LandingPage.tsx
@@ -5,10 +5,12 @@ import RoleCard from '../../components/RoleCard'
 import { useAuth } from '../../contexts/AuthContext'
 import { ApolloWrapper } from '@jaedag/admin-portal-react-core'
 import { Role } from '../../../global'
+import { useUserContext } from '../../contexts/UserContext'
 
 const LandingPage = () => {
   const { currentUser } = useAuth()
   const [roles, setRoles] = useState<Role[]>([])
+  const { setUserRoles, userRoles } = useUserContext()
   const loading = !roles
 
   useEffect(() => {
@@ -17,22 +19,32 @@ const LandingPage = () => {
       let roles: string[] = []
       if (token?.claims?.roles) {
         roles = [...token.claims.roles]
+        setUserRoles(roles)
       }
 
-      const roleMappings: { [key: string]: string } = {
-        countryAdmin: 'campAdmin',
-        campusAdmin: 'campAdmin',
-        continentAdmin: 'campAdmin',
-      }
+      console.log('originalroles', roles)
 
-      // Use filter to keep only 'globalAdmin', 'campCamper', and roles mapped to 'campAdmin'
-      const filteredRoles = roles.filter((role) => {
-        return (
-          role === 'globalAdmin' ||
-          role === 'campCamper' ||
-          roleMappings[role] === 'campAdmin'
-        )
-      })
+      // Check if any of the roles to be replaced exists in the roles array
+      const hasCampRoles = roles.some((role) =>
+        ['continentAdmin', 'countryAdmin', 'campusAdmin'].includes(role)
+      )
+
+      // If any of the roles exist, include 'campAdmin', otherwise keep the original roles
+      const filteredRoles = hasCampRoles
+        ? [
+            ...roles.filter(
+              (role) =>
+                !['continentAdmin', 'countryAdmin', 'campusAdmin'].includes(
+                  role
+                )
+            ),
+            'campAdmin',
+          ]
+        : roles.filter(
+            (role) => role === 'globalAdmin' || role === 'campCamper'
+          )
+
+      console.log('here', filteredRoles)
 
       setRoles(filteredRoles as Role[])
     }

--- a/web-react-ts/src/pages/users/UserProfile.tsx
+++ b/web-react-ts/src/pages/users/UserProfile.tsx
@@ -65,7 +65,6 @@ const UserProfile = () => {
 
   const userReference = doc(firestore, 'users', userEmail)
   const { data: user } = useFirestoreDocData(userReference)
-  console.log('user', user)
 
   const allCamps: UserCampData[] = []
 
@@ -90,8 +89,6 @@ const UserProfile = () => {
       campOptions.push({ key: camp.name, value: camp.id })
     })
   }
-
-  console.log('allCamps', allCamps)
 
   const loading = !user || !campsCollection
 

--- a/web-react-ts/src/utils/constants.ts
+++ b/web-react-ts/src/utils/constants.ts
@@ -13,3 +13,32 @@ export const CAMP_LEVEL_OPTIONS = [
 ]
 
 export const NO_USERS_FOUND_TEXT = 'No Users Found'
+
+export const ROLE_MAPPINGS = {
+  planet: {
+    globalAdmin: ['Campus', 'Country', 'Continent', 'Global'],
+    continentAdmin: ['Campus', 'Country', 'Continent'],
+    countryAdmin: ['Campus', 'Country'],
+    campusAdmin: ['Campus'],
+  },
+  continent: {
+    globalAdmin: ['Campus', 'Country', 'Continent'],
+    continentAdmin: ['Campus', 'Country'],
+    countryAdmin: ['Campus'],
+  },
+  country: {
+    globalAdmin: ['Country', 'Campus'],
+    continentAdmin: ['Campus', 'Country'],
+    countryAdmin: ['Campus'],
+  },
+  campus: {
+    globalAdmin: ['Campus'],
+  },
+}
+
+export const ROLE_WEIGHTS = [
+  { role: 'globalAdmin', weight: 4 },
+  { role: 'continentAdmin', weight: 3 },
+  { role: 'countryAdmin', weight: 2 },
+  { role: 'campusAdmin', weight: 1 },
+]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR implements the method for the global admin to assign admins using the users page.

<!--- Describe your changes in detail -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
This has been tested on my local maching
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots/Videos (if appropriate):
https://www.loom.com/share/a6a40e9e8c1c49d0a59907f35ac33ee5?sid=96143b3b-8658-4440-88c0-c7088a67ac3c
https://www.loom.com/share/f4b2f1fbd83d47d1aaa44ce2d00be896?sid=43a36bdc-86a7-4097-94b5-86fe8bbe5f84

<!--Not optional. Please oblige so that your PR will be merged in due time!-->
